### PR TITLE
Neutral fix

### DIFF
--- a/game/scripts/npc/neutral_items.txt
+++ b/game/scripts/npc/neutral_items.txt
@@ -278,7 +278,7 @@
 		{
 			"item_ballista"					  "1"
 			"item_desolator_2"				  "1"
-			"item_pirate_hat"				  "1"
+			"item_mirror_shield"			  "1"
 			"item_ex_machina"				  "1"
 		}
 	}
@@ -299,7 +299,7 @@
 			"item_giants_ring"		 		  "1"
 			"item_fallen_sky"				  "1"
 			"item_apex"						  "1"
-			"item_mirror_shield"			  "1"
+			"item_pirate_hat"				  "1"
 		}
 	}
 	"15"

--- a/game/scripts/npc/neutral_items.txt
+++ b/game/scripts/npc/neutral_items.txt
@@ -302,4 +302,24 @@
 			"item_mirror_shield"			  "1"
 		}
 	}
+	"15"
+	{
+		"drop_rates"
+		{
+			"56:00"
+			{
+				"0" "10"
+				"1" "10"
+				"2" "10"
+				"3" "10"
+			}
+		}
+		"items"
+		{
+			"item_recipe_trident"		 	  "1"
+			"item_woodland_striders"		  "1"
+			"item_phoenix_ash"				  "1"
+			"item_fusion_rune"			      "1"
+		}
+	}
 }

--- a/game/scripts/npc/neutral_items.txt
+++ b/game/scripts/npc/neutral_items.txt
@@ -148,7 +148,8 @@
 			"item_paladin_sword"			  "1"
 			"item_orb_of_destruction"		  "1"
 			"item_elven_tunic"		 		  "1"
-			"item_minotaur_horn"			  "1"
+			"item_spider_legs"				  "1"
+			
 			
 		}
 	}
@@ -169,7 +170,7 @@
 		{
 			"item_titan_sliver"				  "1"
 			"item_mind_breaker"				  "1"
-			"item_spider_legs"				  "1"
+			"item_minotaur_horn"			  "1"
 			"item_cloak_of_flames"			  "1"
 			
 		}
@@ -193,8 +194,7 @@
 			"item_ceremonial_robe"			  "1"
 			"item_ninja_gear"				  "1"
 			"item_the_leveller"				  "1"
-			"item_penta_edged_sword"		  "1"
-			"item_stormcrafter"				  "1"
+			
 		}
 	}
 	"10"
@@ -212,8 +212,8 @@
 
 		"items"
 		{
-			"item_illusionsts_cape"			  "1"
-			"item_timeless_relic"			  "1"
+			"item_penta_edged_sword"		  "1"
+			"item_stormcrafter"				  "1"
 			"item_spell_prism"				  "1"
 			"item_flicker"					  "1"
 		}
@@ -233,10 +233,11 @@
 
 		"items"
 		{
+			"item_illusionsts_cape"			  "1"
+			"item_timeless_relic"			  "1"
 			"item_spy_gadget"				  "1"
 			"item_trickster_cloak"			  "1"
-			"item_seer_stone"				  "1"
-			"item_apex"						  "1"
+			
 		}
 	}
 	"12"
@@ -254,10 +255,10 @@
 
 		"items"
 		{
-			"item_ballista"					  "1"
+			"item_seer_stone"				  "1"
+			"item_force_boots"				  "1"
+			"item_demonicon"				  "1"
 			"item_book_of_shadows"		  	  "1"
-			"item_giants_ring"		 		  "1"
-			"item_desolator_2"				  "1"
 		}
 	}
 	"13"
@@ -275,8 +276,8 @@
 
 		"items"
 		{
-			"item_demonicon"				  "1"
-			"item_fallen_sky"				  "1"
+			"item_ballista"					  "1"
+			"item_desolator_2"				  "1"
 			"item_pirate_hat"				  "1"
 			"item_ex_machina"				  "1"
 		}
@@ -293,13 +294,12 @@
 				"3" "10"
 			}
 		}
-
 		"items"
 		{
-			"item_force_boots"				  "1"
+			"item_giants_ring"		 		  "1"
+			"item_fallen_sky"				  "1"
+			"item_apex"						  "1"
 			"item_mirror_shield"			  "1"
-			"item_woodland_striders"          "1"
-			"item_recipe_trident"             "1"
 		}
 	}
 }


### PR DESCRIPTION
All tiers now have 4 neutral items.
Increased Number of tiers to 15.
Rebalanced tier 5 neutrals so the stronger ones will appear later.
The 15th tier consists of cycled out tier 5 neutral items. Trident, Woodland Striders, Phoenix Ash and Fusion run.

Full changelog:

Minotaur Horn: Tier 7 -> Tier 8.

Spider Legs: Tier 8 -> Tier 7.

Stormcrafter: Tier 9 -> 10.
Penta edge Sword: Tier 9 -> 10.

Illusionist Cap: Tier 10 ->  11.
Timeless Relic: Tier 10 -> 11.

Seer Stone: Tier 11 ->  12.
Apex: Tier 11 ->  14.

Ballista: Tier  12 -> 13.
Desolator 2: Tier  12 -> 13.
Giant’s Ring: Tier  12 -> 14.

Fallen Sky: Tier 13 -> 14.
Pirate Hat: Tier 13 -> 14.

Mirror Shield: Tier 14-> 13.
Force boots: Tier 14-> 13.
Trident: Tier 14-> 15.
Woodland Striders: Tier 14-> 15. 

Phoenix Ash : Added to tier 15.
Fusion Rune: Added to tier 15.
