### PR TITLE
Supporters can now purchase secret shop items without going to the secret shop

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -284,6 +284,7 @@
 		"you_cannot_control_courier"					                "You cannot control courier"
 		"already_voiting_against_troll"					                "You have already voted the maximum number of times"
 		"you_can_buy_only_one_item"					               		"You can buy only one item of this type"
+		"you_must_be_near_secret_shop"									"You must be near a secret shop to purchase this item!"
 
 		"start_troll_voting_1"					               			"<font color='#FF1111'>[[[</font>%s1<font color='#FF1111'>]]]</font> Start voting for punishment against:"
 		"start_troll_voting_2"					               			"<font color='#FF1111'>[[[</font>%s1<font color='#FF1111'>]]]</font>"

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -139,6 +139,7 @@ function CMegaDotaGameMode:InitGameMode()
 
 	GameRules:GetGameModeEntity():SetKillableTombstones( true )
 	GameRules:GetGameModeEntity():SetFreeCourierModeEnabled(true)
+	GameRules:SetUseUniversalShopMode(true)
 	Convars:SetInt("dota_max_physical_items_purchase_limit", 100)
 	if IsInToolsMode() then
 		GameRules:GetGameModeEntity():SetDraftingBanningTimeOverride(0)
@@ -1377,6 +1378,10 @@ function CMegaDotaGameMode:ExecuteOrderFilter(filterTable)
 			elseif not _G.playerHasTimerWards[playerId] then
 				StartTimerHoldingCheckerForPlayer(playerId)
 			end
+		end
+		if IsSecretShopItem(filterTable["shop_item_name"]) and not ((Supporters:GetLevel(playerId) >= 2) or IsNearSecretShop(unit)) then
+			CustomGameEventManager:Send_ServerToPlayer(PlayerResource:GetPlayer(playerId), "display_custom_error", { message = "#you_must_be_near_secret_shop" })
+			return false
 		end
 	end
 

--- a/game/scripts/vscripts/common/init.lua
+++ b/game/scripts/vscripts/common/init.lua
@@ -9,6 +9,7 @@ require("common/smart_random")
 
 require("common/items_limits")
 require("common/block_holding_wards")
+require("common/secret_shop_items")
 require("common/game_perks/game_perks_core")
 require("common/voting_to_kick")
 require("common/auto_team")

--- a/game/scripts/vscripts/common/secret_shop_items.lua
+++ b/game/scripts/vscripts/common/secret_shop_items.lua
@@ -1,0 +1,34 @@
+_G.secretShopItemList = {
+	item_ring_of_health = true,
+	item_void_stone = true,
+	item_energy_booster = true,
+	item_vitality_booster = true,
+	item_point_booster = true,
+	item_platemail = true,
+	item_talisman_of_evasion = true,
+	item_hyperstone = true,
+	item_ultimate_orb = true,
+	item_demon_edge = true,
+	item_mystic_staff = true,
+	item_reaver = true,
+	item_eagle = true,
+	item_relic = true,
+}
+
+_G.secretShopLocations = {
+	["632"] = Vector(4860, -1228, 192), -- Dire Secret Shop
+	["475"] = Vector(-4894, 1745, 192), -- Radiant Secret Shop
+}
+
+function IsSecretShopItem(itemID)
+	return secretShopItemList[itemID]
+end
+
+function IsNearSecretShop(unit)
+	for radius, shop_location in pairs(secretShopLocations) do
+		if (unit:GetAbsOrigin() - shop_location):Length2D() <= tonumber(radius) then
+			return true
+		end
+	end
+	return false
+end


### PR DESCRIPTION
closes: https://github.com/arcadia-redux/12v12/issues/315
I assume that you have to be tier 2 to do this since I haven't got any reply. Works well with instant buy; secret shop items gets instantly placed into the hero's inventory